### PR TITLE
feat: Separate toast channels for each init call

### DIFF
--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -17,12 +17,18 @@ export type ToastProviderProps<T> = {
   portal?: undefined | HTMLElement;
 };
 
+export type ToastProviderPropsInternal<T> =
+  ToastProviderProps<T> & {
+    channel: string;
+  };
+
 export function ToastProvider<T extends Record<string, any>>(
-  props: ToastProviderProps<T>
+  props: ToastProviderPropsInternal<T>
 ) {
   const { toasts, onRemoveToast } = useToasts({
     removeToastsAfterMs: props.removeToastsAfterMs,
     onToastAdded: props.onToastAdded,
+    channel: props.channel,
   });
 
   if (props.portal) {

--- a/src/useToasts.ts
+++ b/src/useToasts.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { subscribeToToasts } from "./toast";
+import { ToastEventType, subscribeToToasts } from "./toast";
 import { genId } from "./utils";
 
 export type UseToastsOpts<T> = {
@@ -7,9 +7,13 @@ export type UseToastsOpts<T> = {
   removeToastsAfterMs?: number;
 };
 
+export type UseToastsOptsInternal<T> = UseToastsOpts<T> & {
+  channel: string;
+};
+
 /** Listens to all toasts and stores them in a list */
 export function useToasts<T extends Record<string, any>>(
-  opts: UseToastsOpts<T> = {}
+  opts: UseToastsOptsInternal<T> = { channel: ToastEventType }
 ) {
   const mounted = useRef(true);
   const [toasts, setToasts] = useState<(T & { id: string })[]>(
@@ -45,7 +49,7 @@ export function useToasts<T extends Record<string, any>>(
           }
         }, opts.removeToastsAfterMs);
       }
-    });
+    }, opts.channel);
 
     return () => {
       unsubscribe();

--- a/testing-app/src/index.test.tsx
+++ b/testing-app/src/index.test.tsx
@@ -204,3 +204,61 @@ describe("useToasts", () => {
     );
   });
 });
+
+describe("initToast", () => {
+  it("is possible to have separate toast channels", async () => {
+    const user = userEvent.setup();
+    const toastOneUtils = initToast<{
+      title: string;
+    }>();
+    const toastTwoUtils = initToast<{
+      title: string;
+    }>();
+    const Toasts = () => {
+      const { toasts } = toastOneUtils.useToasts();
+      return (
+        <ul>
+          {toasts.map((toast) => (
+            <li key={toast.id}>{toast.title} </li>
+          ))}
+        </ul>
+      );
+    };
+    const App = () => {
+      return (
+        <>
+          <Toasts />
+          <button
+            onClick={() =>
+              toastOneUtils.toast({ title: "Toast 1" })
+            }
+          >
+            Should work
+          </button>
+          <button
+            onClick={() =>
+              toastTwoUtils.toast({ title: "Toast 2" })
+            }
+          >
+            Should not work
+          </button>
+        </>
+      );
+    };
+    render(<App />);
+    expect(screen.queryByRole("listitem")).toBeNull();
+    user.click(
+      screen.getByRole("button", { name: "Should not work" })
+    );
+    await waitFor(() => new Promise((r) => setTimeout(r, 100)));
+    await waitFor(() =>
+      expect(screen.queryByText("Toast 2")).toBeNull()
+    );
+    user.click(
+      screen.getByRole("button", { name: "Should work" })
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Toast 1")).toBeVisible()
+    );
+  });
+});


### PR DESCRIPTION
This should make it so that you can initialize with `initToast` more than once, and have the instances communicate through separate channels.

Example:

```typescript
type Toast = { title: string; };

const appOneToast = initToast<Toast>();
const appTwoToast = initToast<Toast>();

// Now if you were to call `appOneToast.toast()`
appOneToast.toast({ title: "Test" });
// Only the hook & provider from `appOneToast` will receive the toast

const { toasts: toastsOne } = appOneToast.useToasts();
const { toasts: toastsTwo } = appTwoToast.useToasts();

toastsOne.length // 1
toastsTwo.length // 0
```

I do not think there are many use-cases for this, but it would be silly to limit the library so that there only ever can be one channel to communicate through. 