### PR TITLE
feat: Cancel & restart toast timeout

### DIFF
--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -11,6 +11,11 @@ export type ToastProviderProps<T> = {
   renderToasts: (props: {
     toasts: (T & { id: string })[];
     onRemoveToast: (id: string) => void;
+    cancelToastTimeout: (id: string) => void;
+    restartToastTimeout: (
+      id: string,
+      removeAfterMs?: number
+    ) => void;
   }) => ReactElement;
   removeToastsAfterMs?: number;
   onToastAdded?: (toast: T) => void;
@@ -25,7 +30,12 @@ export type ToastProviderPropsInternal<T> =
 export function ToastProvider<T extends Record<string, any>>(
   props: ToastProviderPropsInternal<T>
 ) {
-  const { toasts, onRemoveToast } = useToasts({
+  const {
+    toasts,
+    onRemoveToast,
+    cancelToastTimeout,
+    restartToastTimeout,
+  } = useToasts({
     removeToastsAfterMs: props.removeToastsAfterMs,
     onToastAdded: props.onToastAdded,
     channel: props.channel,
@@ -36,6 +46,8 @@ export function ToastProvider<T extends Record<string, any>>(
       <props.renderToasts
         toasts={toasts}
         onRemoveToast={onRemoveToast}
+        cancelToastTimeout={cancelToastTimeout}
+        restartToastTimeout={restartToastTimeout}
       />,
       props.portal
     );
@@ -45,6 +57,8 @@ export function ToastProvider<T extends Record<string, any>>(
     <props.renderToasts
       toasts={toasts}
       onRemoveToast={onRemoveToast}
+      cancelToastTimeout={cancelToastTimeout}
+      restartToastTimeout={restartToastTimeout}
     />
   );
 }

--- a/testing-app/src/index.test.tsx
+++ b/testing-app/src/index.test.tsx
@@ -203,6 +203,80 @@ describe("useToasts", () => {
       expect(screen.getByText("Foobar")).toBeInTheDocument()
     );
   });
+
+  it("is possible to cancel and restart a toast timeout", async () => {
+    const user = userEvent.setup();
+    const { useToasts, toast } = initToast<{ title: string }>();
+    const Toasts = () => {
+      const {
+        toasts,
+        onRemoveToast,
+        cancelToastTimeout,
+        restartToastTimeout,
+      } = useToasts();
+      return (
+        <ul>
+          {toasts.map((toast) => (
+            <li key={toast.id}>
+              {toast.title}{" "}
+              <button
+                onClick={() => cancelToastTimeout(toast.id)}
+              >
+                Cancel
+              </button>{" "}
+              <button
+                onClick={() => restartToastTimeout(toast.id)}
+              >
+                Restart
+              </button>
+            </li>
+          ))}
+        </ul>
+      );
+    };
+    let i = 0;
+    const App = () => {
+      return (
+        <>
+          <Toasts />
+          <button
+            onClick={() => {
+              i += 1;
+              toast({ title: `Toast ${i}`, removeAfterMs: 200 });
+            }}
+          >
+            Toast
+          </button>
+        </>
+      );
+    };
+    render(<App />);
+    expect(screen.getByRole("list")).toBeEmptyDOMElement();
+    await user.click(
+      screen.getByRole("button", { name: "Toast" })
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Cancel" })
+      ).toBeInTheDocument()
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Cancel" })
+    );
+    await waitFor(
+      () => new Promise((resolve) => setTimeout(resolve, 300))
+    );
+    expect(
+      screen.getByRole("button", { name: "Restart" })
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Restart" })
+    );
+    await waitFor(
+      () => new Promise((resolve) => setTimeout(resolve, 300))
+    );
+    expect(screen.getByRole("list")).toBeEmptyDOMElement();
+  });
 });
 
 describe("initToast", () => {


### PR DESCRIPTION
Adds the possibility to cancel and restart toast timeouts. Useful for implementing behaviours like "pausing" the timeout while the user is hovering a toast. 

- [x] Available in `useToasts`
- [x] Available in `ToastProvider`
- [x] Tests written