### PR TITLE
chore: ensure that providers from the same initToast stay in sync

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -11,14 +11,16 @@ export const ToastEventType = "ryfrea-toast" as const;
 type UnsubscribeFunction = () => void;
 
 export const subscribeToToasts = <T extends Record<string, any>>(
-  onToastAdded: (toast: T & { removeAfterMs?: number }) => void,
+  onToastAdded: (
+    toast: T & { removeAfterMs?: number; id: string }
+  ) => void,
   channel: string
 ): UnsubscribeFunction => {
   const listener = (e: Event) => {
     const event = e as Event & {
-      detail?: T & { removeAfterMs?: number };
+      detail?: T & { removeAfterMs?: number; id: string };
     };
-    if (event.detail) {
+    if (event.detail && event.detail.id) {
       onToastAdded(event.detail);
     }
   };
@@ -34,9 +36,11 @@ export const initToast = <T extends Record<string, any>>() => {
 
   return {
     toast: (args: T & { removeAfterMs?: number }) => {
+      const id = genId();
       document.dispatchEvent(
-        new CustomEvent(channel, { detail: args })
+        new CustomEvent(channel, { detail: { ...args, id } })
       );
+      return id;
     },
     ToastProvider: (props: ToastProviderProps<T>) => (
       <ToastProvider {...props} channel={channel} />


### PR DESCRIPTION
Removing a toast using `useToasts` now also not only removes it in that local hook instance, but throughout every `useToasts` instance from the same initialisation. 

You can still initialise more than once using `initToast` and have the different instances communicate separately. 

If you now have multiple different `ToastProvider`s or `useToasts`s, their toasts IDs will stay consistent between them as long as they are all exported from the same `initToast`.